### PR TITLE
Make compatable with 212.* eap build of intellij

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'my.rs'
-version '1.2-SNAPSHOT'
+version '1.3-SNAPSHOT'
 
 sourceCompatibility = 1.8
 
@@ -26,4 +26,5 @@ intellij {
 
 patchPluginXml {
     changeNotes.set(provider { changelog.getUnreleased().toHTML() })
+    untilBuild.set(provider {  "212.*" })
 }


### PR DESCRIPTION
Added a xml override to change the "until-build" compatibility flag to "212.*" instead of the default value of "211.*"